### PR TITLE
Fix timespan serialization of microseconds

### DIFF
--- a/java/src/main/java/ca/hss/times/WTimeSpan.java
+++ b/java/src/main/java/ca/hss/times/WTimeSpan.java
@@ -386,7 +386,7 @@ public class WTimeSpan implements Comparable<WTimeSpan>, Serializable {
 						str = "1 day " + Long.toString(hour) + ":" + Long.toString(minute);
 					else {
 						if ((flags & WTime.FORMAT_INCLUDE_USECS) > 0)
-							str = String.format("1 day %02d:%02d:%02d:%02d", hour, minute, second, usecs);
+							str = String.format("1 day %02d:%02d:%02d.%02d", hour, minute, second, usecs);
 						else
 							str = String.format("1 day %02d:%02d:%02d", hour, minute, second);
 					}


### PR DESCRIPTION
Microseconds were being split from seconds with a ':' in the Java
version instead of the correct '.'.