### PR TITLE
Update how Intel header files are detected

### DIFF
--- a/cxx/src/SunriseSunsetCalc.cpp
+++ b/cxx/src/SunriseSunsetCalc.cpp
@@ -20,10 +20,12 @@
 
 #ifdef HAVE_HSS_MATH
 #include "mathhss.h"
-#elif defined(INTEL_COMPILER)
+#else
+#if __has_include(<mathimf.h>)
 #include <mathimf.h>
 #else
 #include <cmath>
+#endif
 
 #ifdef _MSC_VER
 void sincos(double val, double* p_sin, double *p_cos)

--- a/cxx/src/Times.cpp
+++ b/cxx/src/Times.cpp
@@ -19,7 +19,7 @@
 
 #include "times_internal.h"
 
-#ifdef INTEL_COMPILER
+#if __has_include(<mathimf.h>)
 #include <mathimf.h>
 #else
 #include <cmath>


### PR DESCRIPTION
Check whether the Intel header files exist instead of using an external flag.