### PR TITLE
Decrementing loop counter needs to be signed

### DIFF
--- a/cxx/src/Times.cpp
+++ b/cxx/src/Times.cpp
@@ -512,7 +512,7 @@ std::string WTimeSpan::ToString(INTNM::uint32_t flags) const {
 						str += ".";
 						std::string temp = "";
 						std::string::size_type zeroIdx = 5;
-						for (size_t i = zeroIdx; i >= 0; i--)
+						for (INTNM::int32_t i = zeroIdx; i >= 0; i--)
 						{
 							INTNM::int32_t digit = usecs % 10;
 							temp = ((char)(digit + '0')) + temp;


### PR DESCRIPTION
The previous update to make it unsigned means the loop will never exit. Switch it back to a signed int.