### PR TITLE
Exception on erase nothing

### DIFF
--- a/cxx/src/TimezoneMapper.cpp
+++ b/cxx/src/TimezoneMapper.cpp
@@ -229,8 +229,8 @@ const ::TimeZoneInfo* TimezoneMapper::getTz(const double lat, const double lng, 
 			}
 		}
 
-		zonestr.erase(std::remove(zonestr.begin(), zonestr.end(), '['));
-		zonestr.erase(std::remove(zonestr.begin(), zonestr.end(), ']'));
+		zonestr.erase(std::remove(zonestr.begin(), zonestr.end(), '['), zonestr.end());
+		zonestr.erase(std::remove(zonestr.begin(), zonestr.end(), ']'), zonestr.end());
 
 		date::zoned_time<date::days> zt1{ zonestr.c_str() };
 		auto tz = zt1.get_time_zone();


### PR DESCRIPTION
When there is nothing to erase and you use the single parameter version of the method it will either throw an exception or build an invalid string. Use the two parameter version that defines an end index to avoid this issue.