### PR TITLE
Update google protobuf dependency version

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.21.10</version>
+      <version>3.25.5</version>
     </dependency>
   </dependencies>
   


### PR DESCRIPTION
Updated the version for the google protobuf dependency from 3.21.10 to 3.25.5 to address a known vulnerability.

For more info see https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java/3.21.10

The most recent version of protobuf at time of writing is 4.29.3, but i assumed sticking to 3.x.x would minimize comparability issues with the existing code.